### PR TITLE
Do not fail when the leader can't be contacted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 1.0.1 - 2019-03-19
+### Fixed
+- Stop failing when the leader can't be contacted
+
 ## 0.1.2 - 2019-03-14
 ### Fixed
 - Stop failing when the leader can't be contacted

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 0.1.2 - 2019-03-14
+### Fixed
+- Stop failing when the leader can't be contacted
+
 ## 0.1.1 - 2018-11-15
 ### Added
 - Datacenter and IP attributes to all Agent samples

--- a/src/consul.go
+++ b/src/consul.go
@@ -45,7 +45,6 @@ func main() {
 	dc, err := datacenter.NewDatacenter(leader, i)
 	if err != nil {
 		log.Error("Error creating Datacenter entity: %s", err.Error())
-		os.Exit(1)
 	}
 
 	// Collect inventory for agents

--- a/src/consul.go
+++ b/src/consul.go
@@ -13,7 +13,7 @@ import (
 
 const (
 	integrationName    = "com.newrelic.consul"
-	integrationVersion = "0.1.1"
+	integrationVersion = "0.1.2"
 )
 
 func main() {

--- a/src/consul.go
+++ b/src/consul.go
@@ -13,7 +13,7 @@ import (
 
 const (
 	integrationName    = "com.newrelic.consul"
-	integrationVersion = "0.1.2"
+	integrationVersion = "1.0.1"
 )
 
 func main() {


### PR DESCRIPTION
#### Description of the changes

In datacenters where the agents can't contact the leader, no metrics are being collected. Now, if datacenter collection fails, the agent metrics are still published.

Fixes #12 

TODO:
- [x] test this on a consul system where the local agent can't contact the leader

#### PR Review Checklist
### Author

- [ ] add a risk label after carefully considering the "blast radius" of your changes
- [ ] describe the _intent_ of your changes in the description. don't just rewrite your code in prose
- [ ] assign at least one reviewer

### Reviewer

- [ ] review code for readability
- [ ] verify that high risk behavior changes are well tested
- [ ] check license for any new external dependency
- [ ] ask questions about anything that isn't clear and obvious
- [ ] approve the PR when you consider it's good to merge
