### PR TITLE
Flags to ignore leader connectivity issues and a flag to treat localhost as leader

### DIFF
--- a/src/agent/agent.go
+++ b/src/agent/agent.go
@@ -35,11 +35,16 @@ func CreateAgents(client *api.Client, i *integration.Integration, args *args.Arg
 		return
 	}
 
-	leaderAddr, err := getLeaderAddr(client)
-	if err != nil {
-		log.Error("Error getting leader address: %s", err.Error())
-		return
+	if args.ForceLocalhostAsLeader {
+		leaderAddr := "127.0.0.1"
+	} else {
+		leaderAddr, err := getLeaderAddr(client)
+		if err != nil {
+			log.Error("Error getting leader address: %s", err.Error())
+			return
+		}
 	}
+
 
 	agents = make([]*Agent, 0, len(members))
 	for _, member := range members {

--- a/src/args/argument_list.go
+++ b/src/args/argument_list.go
@@ -20,6 +20,7 @@ type ArgumentList struct {
 	CABundleFile                   string `default:"" help:"Alternative Certificate Authority bundle file"`
 	CABundleDir                    string `default:"" help:"Alternative Certificate Authority bundle directory"`
 	TolerateLeaderConnectionIssues bool   `default:"false" help:"Tolerate issues connecting to leaders"`
+	ForceLocalhostAsLeader         bool   `default:"false" help:"Leader will be configured as localhost"`
 }
 
 // Validate validates Consul arguments

--- a/src/args/argument_list.go
+++ b/src/args/argument_list.go
@@ -12,13 +12,14 @@ import (
 // ArgumentList struct that holds all Consul arguments
 type ArgumentList struct {
 	sdkArgs.DefaultArgumentList
-	Hostname               string `default:"localhost" help:"The agent node Hostname or IP address to connect to"`
-	Port                   string `default:"8500" help:"Port to connect to agent node"`
-	Token                  string `default:"" help:"ACL Token if token authentication is enabled"`
-	EnableSSL              bool   `default:"false" help:"If true will use SSL encryption, false will not use encryption"`
-	TrustServerCertificate bool   `default:"false" help:"If true server certificate is not verified for SSL. If false certificate will be verified against supplied certificate"`
-	CABundleFile           string `default:"" help:"Alternative Certificate Authority bundle file"`
-	CABundleDir            string `default:"" help:"Alternative Certificate Authority bundle directory"`
+	Hostname                       string `default:"localhost" help:"The agent node Hostname or IP address to connect to"`
+	Port                           string `default:"8500" help:"Port to connect to agent node"`
+	Token                          string `default:"" help:"ACL Token if token authentication is enabled"`
+	EnableSSL                      bool   `default:"false" help:"If true will use SSL encryption, false will not use encryption"`
+	TrustServerCertificate         bool   `default:"false" help:"If true server certificate is not verified for SSL. If false certificate will be verified against supplied certificate"`
+	CABundleFile                   string `default:"" help:"Alternative Certificate Authority bundle file"`
+	CABundleDir                    string `default:"" help:"Alternative Certificate Authority bundle directory"`
+	TolerateLeaderConnectionIssues bool   `default:"false" help:"Tolerate issues connecting to leaders"`
 }
 
 // Validate validates Consul arguments

--- a/src/consul.go
+++ b/src/consul.go
@@ -45,7 +45,9 @@ func main() {
 	dc, err := datacenter.NewDatacenter(leader, i)
 	if err != nil {
 		log.Error("Error creating Datacenter entity: %s", err.Error())
-		os.Exit(1)
+		if !args.TolerateLeaderConnectionIssues {
+			os.Exit(1)
+		}
 	}
 
 	// Collect inventory for agents
@@ -56,7 +58,9 @@ func main() {
 	// Collect metrics for Agents and cluster
 	if args.HasMetrics() {
 		agent.CollectMetrics(agents)
-		dc.CollectMetrics()
+		if dc != nil {
+			dc.CollectMetrics()
+		}
 	}
 
 	if err = i.Publish(); err != nil {


### PR DESCRIPTION
#### Description of the changes

Relates #12. Low risk to work around if leaders are not accessible.

Adds flags to treat localhost as the leader, as well as a flag to not fail on contacting the leader.

#### PR Review Checklist
### Author

- [ ] add a risk label after carefully considering the "blast radius" of your changes
- [ ] describe the _intent_ of your changes in the description. don't just rewrite your code in prose
- [ ] assign at least one reviewer

### Reviewer

- [ ] review code for readability
- [ ] verify that high risk behavior changes are well tested
- [ ] check license for any new external dependency
- [ ] ask questions about anything that isn't clear and obvious
- [ ] approve the PR when you consider it's good to merge
