### PR TITLE
Use CURDIR instead of PWD for directory expansion

### DIFF
--- a/Makefile-docker.mk
+++ b/Makefile-docker.mk
@@ -4,11 +4,11 @@ INTEGRATION_DIR := nri-$(INTEGRATION)
 docker-fmt:
 	@echo "=== $(INTEGRATION) === [ docker-fmt ]: Running gofmt in Docker..."
 	@echo "Using Docker image $(DOCKER_IMAGE)"
-	@docker run -it --rm -v $(PWD):/go/src/github.com/newrelic/$(INTEGRATION_DIR) -w /go/src/github.com/newrelic/$(INTEGRATION_DIR) $(DOCKER_IMAGE) "gofmt" "-s" "-w" "."
+	@docker run -it --rm -v $(CURDIR):/go/src/github.com/newrelic/$(INTEGRATION_DIR) -w /go/src/github.com/newrelic/$(INTEGRATION_DIR) $(DOCKER_IMAGE) "gofmt" "-s" "-w" "."
 
 docker-make:
 	@echo "=== $(INTEGRATION) === [ docker-make ]: Running make in Docker..."
 	@echo "Using Docker image $(DOCKER_IMAGE)"
-	@docker run -it --rm -v $(PWD):/go/src/github.com/newrelic/$(INTEGRATION_DIR) -w /go/src/github.com/newrelic/$(INTEGRATION_DIR) $(DOCKER_IMAGE) "make"
+	@docker run -it --rm -v $(CURDIR):/go/src/github.com/newrelic/$(INTEGRATION_DIR) -w /go/src/github.com/newrelic/$(INTEGRATION_DIR) $(DOCKER_IMAGE) "make"
 
 .PHONY: docker-fmt docker-make


### PR DESCRIPTION
This allows for recursive usage of Make. We deploy programs like this one via debian packages and want to continue to use our internal Make-based framework for doing so. This means that we have a top level Makefile that invokes Make for nri-consul like so:
```sh
/my/build/path $ make -C download/nri-consul-0.1.1/Makefile docker-make
```

Unfortunately the use of `$(PWD)` ignores the `-C` flag and resolves to `/my/build/path` which no longer works with the script. 

`$(CURDIR)` respects the `-C` flag when supplied without breaking the behavior from `$(PWD)` here (or so I assume, really. I'm basing most of this off of [this stackoverflow question](https://stackoverflow.com/questions/52437728/bash-what-is-the-difference-between-pwd-and-curdir))

#### PR Review Checklist
### Author

- [ ] add a risk label after carefully considering the "blast radius" of your changes
- [ ] describe the _intent_ of your changes in the description. don't just rewrite your code in prose
- [ ] assign at least one reviewer

### Reviewer

- [ ] review code for readability
- [ ] verify that high risk behavior changes are well tested
- [ ] check license for any new external dependency
- [ ] ask questions about anything that isn't clear and obvious
- [ ] approve the PR when you consider it's good to merge
