### PR TITLE
Add support for local-only collection

### DIFF
--- a/src/agent/inventory.go
+++ b/src/agent/inventory.go
@@ -39,20 +39,26 @@ func inventoryWorker(agentChan <-chan *Agent, wg *sync.WaitGroup) {
 			return
 		}
 
-		selfData, err := agent.Client.Agent().Self()
-		if err != nil {
-			log.Error("Error retrieving self configuration data for Agent '%s': %s", agent.entity.Metadata.Name, err.Error())
-			continue
-		}
-
-		// Config data
-		if configData, ok := selfData["Config"]; ok {
-			agent.processConfig(configData, "Config")
-		}
-
-		// Debug config data
-		if debugConfig, ok := selfData["DebugConfig"]; ok {
-			agent.processConfig(debugConfig, "DebugConfig")
-		}
+		CollectInventoryFromOne(agent)
 	}
+}
+
+//CollectInventoryFromOne collects inventory data for a single agent entity
+func CollectInventoryFromOne(agent *Agent) {
+	selfData, err := agent.Client.Agent().Self()
+	if err != nil {
+		log.Error("Error retrieving self configuration data for Agent '%s': %s", agent.entity.Metadata.Name, err.Error())
+		return
+	}
+
+	// Config data
+	if configData, ok := selfData["Config"]; ok {
+		agent.processConfig(configData, "Config")
+	}
+
+	// Debug config data
+	if debugConfig, ok := selfData["DebugConfig"]; ok {
+		agent.processConfig(debugConfig, "DebugConfig")
+	}
+
 }

--- a/src/agent/metric_collection.go
+++ b/src/agent/metric_collection.go
@@ -40,26 +40,33 @@ func metricWorker(agentChan <-chan *Agent, wg *sync.WaitGroup) {
 			return
 		}
 
-		metricSet := agent.entity.NewMetricSet("ConsulAgentSample",
-			metric.Attribute{Key: "displayName", Value: agent.entity.Metadata.Name},
-			metric.Attribute{Key: "entityName", Value: agent.entity.Metadata.Namespace + ":" + agent.entity.Metadata.Name},
-			metric.Attribute{Key: "ip", Value: agent.ipAddr},
-			metric.Attribute{Key: "datacenter", Value: agent.datacenter},
-		)
+		CollectMetricsFromOne(agent)
 
-		// Collect core metrics
-		if err := agent.CollectCoreMetrics(metricSet, gaugeMetrics, counterMetrics, timerMetrics); err != nil {
-			log.Error("Error collecting core metrics for Agent '%s': %s", agent.entity.Metadata.Name, err.Error())
-		}
-
-		// Peer Count
-		if err := agent.collectPeerCount(metricSet); err != nil {
-			log.Error("Error collecting peer count for Agent '%s': %s", agent.entity.Metadata.Name, err.Error())
-		}
-
-		// Latency metrics
-		if err := agent.collectLatencyMetrics(metricSet); err != nil {
-			log.Error("Error collecting latency metrics for Agent '%s': %s", agent.entity.Metadata.Name, err.Error())
-		}
 	}
+}
+
+// CollectMetricsFromOne does a metric collect for a single agent
+func CollectMetricsFromOne(agent *Agent) {
+	metricSet := agent.entity.NewMetricSet("ConsulAgentSample",
+		metric.Attribute{Key: "displayName", Value: agent.entity.Metadata.Name},
+		metric.Attribute{Key: "entityName", Value: agent.entity.Metadata.Namespace + ":" + agent.entity.Metadata.Name},
+		metric.Attribute{Key: "ip", Value: agent.ipAddr},
+		metric.Attribute{Key: "datacenter", Value: agent.datacenter},
+	)
+
+	// Collect core metrics
+	if err := agent.CollectCoreMetrics(metricSet, gaugeMetrics, counterMetrics, timerMetrics); err != nil {
+		log.Error("Error collecting core metrics for Agent '%s': %s", agent.entity.Metadata.Name, err.Error())
+	}
+
+	// Peer Count
+	if err := agent.collectPeerCount(metricSet); err != nil {
+		log.Error("Error collecting peer count for Agent '%s': %s", agent.entity.Metadata.Name, err.Error())
+	}
+
+	// Latency metrics
+	if err := agent.collectLatencyMetrics(metricSet); err != nil {
+		log.Error("Error collecting latency metrics for Agent '%s': %s", agent.entity.Metadata.Name, err.Error())
+	}
+
 }

--- a/src/args/argument_list.go
+++ b/src/args/argument_list.go
@@ -19,6 +19,7 @@ type ArgumentList struct {
 	TrustServerCertificate bool   `default:"false" help:"If true server certificate is not verified for SSL. If false certificate will be verified against supplied certificate"`
 	CABundleFile           string `default:"" help:"Alternative Certificate Authority bundle file"`
 	CABundleDir            string `default:"" help:"Alternative Certificate Authority bundle directory"`
+	FanOut                 bool   `default:"true" help:"If true will attempt to gather metrics from all other nodes in consul cluster"`
 }
 
 // Validate validates Consul arguments

--- a/src/consul.go
+++ b/src/consul.go
@@ -1,7 +1,9 @@
 package main
 
 import (
+	"fmt"
 	"os"
+	"strconv"
 
 	"github.com/hashicorp/consul/api"
 	"github.com/newrelic/infra-integrations-sdk/integration"
@@ -35,16 +37,36 @@ func main() {
 		os.Exit(1)
 	}
 
-	// Create the list of agents in LAN pool
-	agents, leader, err := agent.CreateAgents(client, i, &args)
-	if err != nil {
-		log.Error("Error creating Agent entities: %s", err.Error())
+	var collectionError error
+	if args.FanOut {
+		collectionError = fanOutCollection(client, i, &args)
+	} else {
+		collectionError = localCollection(client, i, &args)
+	}
+
+	if collectionError != nil {
+		log.Error("Error collecting metrics: %s", collectionError.Error())
 		os.Exit(1)
+	}
+
+	if err = i.Publish(); err != nil {
+		log.Error("Failed to publish metrics: %s", err.Error())
+		os.Exit(1)
+	}
+}
+
+func fanOutCollection(client *api.Client, i *integration.Integration, args *args.ArgumentList) error {
+	// Create the list of agents in LAN pool
+	agents, leader, err := agent.CreateAgents(client, i, args)
+	if err != nil {
+		return fmt.Errorf("Error creating Agent entities: %s", err.Error())
 	}
 
 	dc, err := datacenter.NewDatacenter(leader, i)
 	if err != nil {
 		log.Error("Error creating Datacenter entity: %s", err.Error())
+	} else if args.HasMetrics() {
+		dc.CollectMetrics()
 	}
 
 	// Collect inventory for agents
@@ -55,10 +77,88 @@ func main() {
 	// Collect metrics for Agents and cluster
 	if args.HasMetrics() {
 		agent.CollectMetrics(agents)
-		dc.CollectMetrics()
 	}
 
-	if err = i.Publish(); err != nil {
-		log.Error(err.Error())
+	return nil
+}
+
+func maybeConvertBool(value interface{}) (bool, error) {
+	switch v := value.(type) {
+	default:
+		return false, fmt.Errorf("Unexpected type: %T", v)
+	case bool:
+		return value.(bool), nil
+	case string:
+		val, err := strconv.ParseBool(value.(string))
+		if err != nil {
+			return false, fmt.Errorf("Unable to convert %v to a bool: %v", value, err)
+		}
+		return val, nil
 	}
+}
+
+func localCollection(client *api.Client, i *integration.Integration, args *args.ArgumentList) error {
+	localAgentData, err := client.Agent().Self()
+	if err != nil {
+		return fmt.Errorf("Failed to collect local agent data: %v", err)
+	}
+
+	// TODO: It would be nice if this was available to us as a MemberAgent
+	//       object but I don't think it is
+	member, ok := localAgentData["Member"]
+	if !ok {
+		return fmt.Errorf("Failed to get local agent member: %v", ok)
+	}
+
+	memberName, ok := member["Name"].(string)
+	if !ok {
+		return fmt.Errorf("Failed to get member name: %v", ok)
+	}
+
+	memberAddr, ok := member["Addr"].(string)
+	if !ok {
+		return fmt.Errorf("Failed to get member address: %v", ok)
+	}
+
+	memberDataCenter, ok := member["Tags"].(map[string]interface{})["dc"].(string)
+	if !ok {
+		return fmt.Errorf("Failed to get member datacenter: %v", ok)
+	}
+
+	isLeaderValue, ok := localAgentData["Stats"]["consul"].(map[string]interface{})["leader"]
+	if !ok {
+		return fmt.Errorf("Failed to check for leadership: %v", ok)
+	}
+
+	// The key currently comes back to us as a string, so we convert it if we need to
+	// Little bit of future proofing in case the api changes
+	isLeader, err := maybeConvertBool(isLeaderValue)
+	if err != nil {
+		log.Error("Leadership value is not a bool. Defaulting to false: %v", err)
+		isLeader = false
+	}
+
+	entity, err := i.Entity(memberName, "agent")
+	agentInstance := agent.NewAgent(client, entity, memberAddr, memberDataCenter)
+
+	if args.HasMetrics() {
+		if isLeader {
+			log.Debug("Checking Leader Metrics")
+			dc, err := datacenter.NewDatacenter(agentInstance, i)
+			if err != nil {
+				log.Error("Failed to get datacenter metrics: %v", err)
+			} else {
+				dc.CollectMetrics()
+			}
+		} else {
+			log.Debug("Not Checking Leader Metrics")
+		}
+		agent.CollectMetricsFromOne(agentInstance)
+	}
+
+	if args.HasInventory() {
+		agent.CollectInventoryFromOne(agentInstance)
+	}
+
+	return nil
 }


### PR DESCRIPTION
#### Description of the changes

Prior to this PR, a single install of this integration tries to get metrics for all agents in a consul cluster (I've called this 'fanout'). We lock our consul nodes down so that the APIs can only be accessed via localhost - this means that we can't get any data from this integration.

I've changed this integration to only look at the local host. This means that if we want to gather inventory data or other metrics from all nodes in a consul cluster then the integration will have to be installed and running on all nodes. 


#### PR Review Checklist
### Author

- [ ] add a risk label after carefully considering the "blast radius" of your changes
- [ ] describe the _intent_ of your changes in the description. don't just rewrite your code in prose
- [ ] assign at least one reviewer

### Reviewer

- [ ] review code for readability
- [ ] verify that high risk behavior changes are well tested
- [ ] check license for any new external dependency
- [ ] ask questions about anything that isn't clear and obvious
- [ ] approve the PR when you consider it's good to merge
