### PR TITLE
Fix packaging signtool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 Unreleased section should follow [Release Toolkit](https://github.com/newrelic/release-toolkit#render-markdown-and-update-markdown)
 ## Unreleased
+### bugfix
+- Fix Windows packaging signtool path
 
 ## v2.7.6 - 2024-02-26
 

--- a/build/package/windows/nri-386-installer/nri-installer.wixproj
+++ b/build/package/windows/nri-386-installer/nri-installer.wixproj
@@ -8,7 +8,7 @@
         <SchemaVersion>2.0</SchemaVersion>
         <OutputName>nri-$(IntegrationName)-386</OutputName>
         <OutputType>Package</OutputType>
-        <SignToolPath>C:\Program Files (x86)\Windows Kits\10\bin\x64\</SignToolPath>
+        <SignToolPath>C:\Program Files (x86)\Microsoft SDKs\ClickOnce\SignTool\</SignToolPath>
         <WixTargetsPath Condition=" '$(WixTargetsPath)' == '' AND '$(MSBuildExtensionsPath32)' != '' ">$(MSBuildExtensionsPath32)\Microsoft\WiX\v3.x\Wix.targets</WixTargetsPath>
         <WixTargetsPath Condition=" '$(WixTargetsPath)' == '' ">$(MSBuildExtensionsPath)\Microsoft\WiX\v3.x\Wix.targets</WixTargetsPath>
         <Name>newrelic-nri-$(IntegrationName)-installer</Name>

--- a/build/package/windows/nri-amd64-installer/nri-installer.wixproj
+++ b/build/package/windows/nri-amd64-installer/nri-installer.wixproj
@@ -8,7 +8,7 @@
         <SchemaVersion>2.0</SchemaVersion>
         <OutputName>nri-$(IntegrationName)-amd64</OutputName>
         <OutputType>Package</OutputType>
-        <SignToolPath>C:\Program Files (x86)\Windows Kits\10\bin\x64\</SignToolPath>
+        <SignToolPath>C:\Program Files (x86)\Microsoft SDKs\ClickOnce\SignTool\</SignToolPath>
         <WixTargetsPath Condition=" '$(WixTargetsPath)' == '' AND '$(MSBuildExtensionsPath32)' != '' ">$(MSBuildExtensionsPath32)\Microsoft\WiX\v3.x\Wix.targets</WixTargetsPath>
         <WixTargetsPath Condition=" '$(WixTargetsPath)' == '' ">$(MSBuildExtensionsPath)\Microsoft\WiX\v3.x\Wix.targets</WixTargetsPath>
         <Name>newrelic-nri-$(IntegrationName)-installer</Name>


### PR DESCRIPTION
[Pre-release failed ](https://github.com/newrelic/nri-consul/actions/runs/8042698745) because the signtool was not in the path that the Wix project states.

This should fix the pre-release.