### PR TITLE
Bump to golang version v1.21.7

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.20.7-bookworm
+FROM golang:1.21.7-bookworm
 
 ARG GH_VERSION='1.6.0'
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/newrelic/nri-consul
 
-go 1.20
+go 1.21.7
 
 require (
 	github.com/hashicorp/consul/api v1.28.2

--- a/test/integration/docker-compose.yml
+++ b/test/integration/docker-compose.yml
@@ -43,7 +43,7 @@ services:
     command: "agent -bootstrap-expect=3"
 
   nri-consul:
-    image: golang:1.20-buster
+    image: golang:1.21.7-bookworm
     container_name: nri_consul
     working_dir: /code
     volumes:


### PR DESCRIPTION
This PR bumps Golang to version `v1.21.7`.